### PR TITLE
Bookkeeping voted amounts for each address in TokenizedBallot.sol

### DIFF
--- a/Week3/contracts/TokenizedBallot.sol
+++ b/Week3/contracts/TokenizedBallot.sol
@@ -13,6 +13,7 @@ contract TokenizedBallot {
     IMyToken public tokenContract;
     Proposal[] public proposals;
     uint256 public targetBlockNumber;
+    mapping(address => uint256) public votedAmount; // Mapping to track how much each address has voted
 
     constructor(
         bytes32[] memory _proposalNames,
@@ -30,7 +31,11 @@ contract TokenizedBallot {
     }
 
     function vote(uint256 proposal, uint256 amount) external {
-        require(tokenContract.getPastVotes(msg.sender, targetBlockNumber) >= amount, "Voter does not have enough voting power");
+        // Get the sender's past votes
+        uint256 pastVotes = tokenContract.getPastVotes(msg.sender, targetBlockNumber);
+        // Ensure the sender has enough tokens to vote
+        require(votedAmount[msg.sender] + amount <= pastVotes, "Voter does not have enough voting power");
+        votedAmount[msg.sender] += amount;
         proposals[proposal].voteCount += amount;
     }
 


### PR DESCRIPTION
I believe we have to keep a record of how much voting power each address has spent already, since each voting action could be invoked with an arbitrary amount of voting power. Let me know if this sounds reasonable!

I wasn't able to deploy this yet since I had an out of gas error so I don't know if it's correct yet 😞 
https://sepolia.etherscan.io/tx/0xe2e7ed48b06895cbda578a3d978105fb8268559e2a43f4708dd4d66e55db87b5

Please let me know if you know how to fix this error! Thanks!